### PR TITLE
feat: populate facilities lds

### DIFF
--- a/db/sql/facilities_lds/functions/populate_facilities_lds.sql
+++ b/db/sql/facilities_lds/functions/populate_facilities_lds.sql
@@ -1,0 +1,51 @@
+CREATE OR REPLACE FUNCTION facilities_lds.nz_facilities_insert()
+RETURNS integer AS
+$$
+
+    WITH populate_nz_facilities AS (
+        INSERT INTO facilities_lds.nz_facilities (
+              facility_id
+            , source_facility_id
+            , name
+            , source_name
+            , use
+            , use_type
+            , use_subtype
+            , estimated_occupancy
+            , last_modified
+            , shape
+        )
+        SELECT
+              facility_id
+            , source_facility_id
+            , name
+            , source_name
+            , use
+            , use_type
+            , use_subtype
+            , estimated_occupancy
+            , last_modified
+            , shape
+        FROM facilities.facilities
+        RETURNING *
+    )
+    SELECT count(*)::integer FROM populate_nz_facilities;
+
+$$
+LANGUAGE sql VOLATILE;
+
+CREATE OR REPLACE FUNCTION facilities_lds.populate_facilities_lds()
+RETURNS TABLE(
+      table_name text
+    , rows_inserted integer
+) AS
+$$
+
+    TRUNCATE facilities_lds.nz_facilities;
+
+    VALUES
+          ('nz_facilities' , facilities_lds.nz_facilities_insert())
+    ;
+
+$$
+LANGUAGE sql VOLATILE;


### PR DESCRIPTION
Feature: Process added to update `facilities_lds.nz_facilities` table from `facilities.facilities` table in preparation for publishing to the LDS.

This is achieved with the same approach as for `nz_buildings`:
- Postgres function that updates the tables is added to the database (one-off change)
- Function is run by a user when required, by running `SELECT facilities_lds.populate_facilities_lds();` in pgAdmin or similar
    - Features in `nz_facilities` table are automatically deleted
    - Features from `facilities` are automatically copied to `nz_facilities` (relevant columns only)

**For Testing:**
**Either**

1. Create a new blank Postgres database and add postgis extension
2. Download and save this backup file [facilities_test.zip](https://github.com/user-attachments/files/23179153/facilities_test.zip)
3. Using Terminal command line (this was more successful than via pgAdmin), restore the backup file into your new DB by using something similar to: `pg_restore -h localhost -U postgres -d your_db_name -v  -O -v -x --no-table-access-method "/home/dkwan/dev2/testing/populate_facilities_lds/facilities_test.backup"`
4. Check `facilities` and `nz_facilities` table differences
5. Run `SELECT facilities_lds.populate_facilities_lds();` in pgAdmin
6. Check if the nz_facilities table is now updated

**OR**
- Use your own database and `facilities` and `nz_facilities` tables instead
- Copy the code contents of `populate_facilities_lds.sql` and paste into pgAdmin query window and run (to create the functions required)
- Continue from Step 4 above.
